### PR TITLE
WIP: Improve inference of unflatten

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ParameterHandling"
 uuid = "2412ca09-6db7-441c-8e3a-88d5709968c5"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/flatten.jl
+++ b/src/flatten.jl
@@ -31,7 +31,10 @@ function flatten(::Type{T}, x::R) where {T<:Real,R<:Real}
     return v, unflatten_to_Real
 end
 
-flatten(::Type{T}, x::Vector{R}) where {T<:Real,R<:Real} = (Vector{T}(x), Vector{R})
+function flatten(::Type{T}, x::Vector{R}) where {T<:Real,R<:Real}
+    unflatten_to_Vector(v) = Vector{R}(v)
+    return Vector{T}(x), unflatten_to_Vector
+end
 
 function _flatten_vector_integer(::Type{T}, x::AbstractVector{<:Integer}) where {T<:Real}
     unflatten_to_Vector_Integer(x_vec) = x

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -148,9 +148,9 @@ Base.:(==)(a::Deferred, b::Deferred) = (a.f == b.f) && (a.args == b.args)
 
 value(x::Deferred) = x.f(value(x.args)...)
 
-function flatten(::Type{T}, x::D) where {T<:Real, D<:Deferred}
+function flatten(::Type{T}, x::Deferred) where {T<:Real}
     v, unflatten = flatten(T, x.args)
-    unflatten_Deferred(v_new::Vector{T}) = D(x.f, unflatten(v_new))
+    unflatten_Deferred(v_new::Vector{T}) = Deferred(x.f, unflatten(v_new))
     return v, unflatten_Deferred
 end
 

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -148,9 +148,9 @@ Base.:(==)(a::Deferred, b::Deferred) = (a.f == b.f) && (a.args == b.args)
 
 value(x::Deferred) = x.f(value(x.args)...)
 
-function flatten(::Type{T}, x::Deferred) where {T<:Real}
+function flatten(::Type{T}, x::D) where {T<:Real, D<:Deferred}
     v, unflatten = flatten(T, x.args)
-    unflatten_Deferred(v_new::Vector{T}) = Deferred(x.f, unflatten(v_new))
+    unflatten_Deferred(v_new::Vector{T}) = D(x.f, unflatten(v_new))
     return v, unflatten_Deferred
 end
 

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -150,7 +150,7 @@ value(x::Deferred) = x.f(value(x.args)...)
 
 function flatten(::Type{T}, x::Deferred) where {T<:Real}
     v, unflatten = flatten(T, x.args)
-    unflatten_Deferred(v_new::Vector{T}) = Deferred(x.f, unflatten(v_new))
+    @inline unflatten_Deferred(v_new::Vector{T}) = Deferred(x.f, unflatten(v_new))
     return v, unflatten_Deferred
 end
 

--- a/src/test_utils.jl
+++ b/src/test_utils.jl
@@ -43,6 +43,7 @@ function test_flatten_interface(x::T; check_inferred::Bool=true) where {T}
 
         # Check that everything infers properly.
         check_inferred && @inferred flatten(x)
+        check_inferred && @inferred unflatten(v)
 
         # Test with different precisions
         @testset "Float64" begin
@@ -54,6 +55,7 @@ function test_flatten_interface(x::T; check_inferred::Bool=true) where {T}
 
             # Check that everything infers properly.
             check_inferred && @inferred flatten(Float64, x)
+            check_inferred && @inferred _unflatten(_v)
         end
         @testset "Float32" begin
             _v, _unflatten = flatten(Float32, x)
@@ -63,6 +65,7 @@ function test_flatten_interface(x::T; check_inferred::Bool=true) where {T}
 
             # Check that everything infers properly.
             check_inferred && @inferred flatten(Float32, x)
+            check_inferred && @inferred _unflatten(_v)
         end
         @testset "Float16" begin
             _v, _unflatten = flatten(Float16, x)
@@ -72,6 +75,7 @@ function test_flatten_interface(x::T; check_inferred::Bool=true) where {T}
 
             # Check that everything infers properly.
             check_inferred && @inferred flatten(Float16, x)
+            check_inferred && @inferred _unflatten(_v)
         end
     end
 

--- a/test/parameters.jl
+++ b/test/parameters.jl
@@ -39,11 +39,12 @@ pdiagmat(args...) = PDiagMat(args...)
     @testset "deferred" begin
         test_parameter_interface(deferred(sin, 0.5); check_inferred=tuple_infers)
         test_parameter_interface(deferred(sin, positive(0.5)); check_inferred=tuple_infers)
+
         test_parameter_interface(
             deferred(
                 mvnormal, fixed(randn(5)), deferred(pdiagmat, positive.(rand(5) .+ 1e-1))
             );
-            check_inferred=tuple_infers,
+            check_inferred=false, # flatten infers, unflatten doesn't
         )
     end
 

--- a/test/parameters.jl
+++ b/test/parameters.jl
@@ -39,12 +39,11 @@ pdiagmat(args...) = PDiagMat(args...)
     @testset "deferred" begin
         test_parameter_interface(deferred(sin, 0.5); check_inferred=tuple_infers)
         test_parameter_interface(deferred(sin, positive(0.5)); check_inferred=tuple_infers)
-
         test_parameter_interface(
             deferred(
                 mvnormal, fixed(randn(5)), deferred(pdiagmat, positive.(rand(5) .+ 1e-1))
             );
-            check_inferred=false, # flatten infers, unflatten doesn't
+            check_inferred=tuple_infers,
         )
     end
 


### PR DESCRIPTION
This is pretty minor but I noticed that there are a few cases where `unflatten` doesn't seem to infer. 

Some exampes in master on 1.6:

```
v, unflatten = flatten(deferred(vec, rand(5,)))
@inferred unflatten(rand(5,)) # return type ParameterHandling.Deferred{typeof(vec), Tuple{Vector{Float64}}} does not match inferred return type ParameterHandling.Deferred{typeof(vec), _A} where _A

v, unflatten = flatten(rand(4,4))
@inferred unflatten(rand(16,)) # return type Matrix{Float64} does not match inferred return type Any

```

Adding a test for type inference into the test sets shows up a few. I'm aware of the  gotcha listed on the docs - ironically that one seems to work on master (Normal => normal)

This MR:
* Adds inference tests into the test suite
* Improved types inferece for a few of the flatten functions that showed up errors. This is through a revised 'oftype' function that has a type annotation. I tend not to see these used, is there a reason not to? It is a little surprising because this is the output of `oftype`, so it should know the output. 

I came to this because I was seeing some inference issues as part of the CRTU tests using a program with deferred, so put this MR together





 

