### PR TITLE
Add method `value(::Nothing)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ParameterHandling"
 uuid = "2412ca09-6db7-441c-8e3a-88d5709968c5"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.4.9"
+version = "0.4.10"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/parameters_base.jl
+++ b/src/parameters_base.jl
@@ -18,3 +18,4 @@ value(x::AbstractArray) = map(value, x)
 value(x::Tuple) = map(value, x)
 value(x::NamedTuple) = map(value, x)
 value(x::Dict) = Dict(k => value(v) for (k, v) in x)
+value(::Nothing) = nothing

--- a/test/parameters.jl
+++ b/test/parameters.jl
@@ -62,7 +62,7 @@
     end
 
     @testset "value_flatten" begin
-        x = (ones(3), fixed(5.0), (a=fixed(5.0), b=[6.0, 2.1]))
+        x = (ones(3), fixed(5.0), (a=fixed(5.0), b=[6.0, 2.1]), nothing)
         v, unflatten = value_flatten(x)
 
         @test length(v) == 5


### PR DESCRIPTION
I did not notice this, but of course this is required to make the full use case work.
I threw in a `nothing` in the integration test.