### PR TITLE
Add epsilon to `PositiveDefinite`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ParameterHandling"
 uuid = "2412ca09-6db7-441c-8e3a-88d5709968c5"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.4.10"
+version = "0.5.0"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/ParameterHandling.jl
+++ b/src/ParameterHandling.jl
@@ -14,8 +14,7 @@ export flatten,
     fixed,
     deferred,
     orthogonal,
-    positive_definite,
-    positive_semidefinite
+    positive_definite
 
 include("flatten.jl")
 include("parameters_base.jl")

--- a/src/ParameterHandling.jl
+++ b/src/ParameterHandling.jl
@@ -8,7 +8,8 @@ using LinearAlgebra
 using SparseArrays
 
 export flatten,
-    value_flatten, positive, bounded, fixed, deferred, orthogonal, positive_definite
+    value_flatten, positive, bounded, fixed, deferred, orthogonal, positive_definite,
+    positive_semidefinite
 
 include("flatten.jl")
 include("parameters_base.jl")

--- a/src/ParameterHandling.jl
+++ b/src/ParameterHandling.jl
@@ -8,7 +8,13 @@ using LinearAlgebra
 using SparseArrays
 
 export flatten,
-    value_flatten, positive, bounded, fixed, deferred, orthogonal, positive_definite,
+    value_flatten,
+    positive,
+    bounded,
+    fixed,
+    deferred,
+    orthogonal,
+    positive_definite,
     positive_semidefinite
 
 include("flatten.jl")

--- a/src/ParameterHandling.jl
+++ b/src/ParameterHandling.jl
@@ -8,13 +8,7 @@ using LinearAlgebra
 using SparseArrays
 
 export flatten,
-    value_flatten,
-    positive,
-    bounded,
-    fixed,
-    deferred,
-    orthogonal,
-    positive_definite
+    value_flatten, positive, bounded, fixed, deferred, orthogonal, positive_definite
 
 include("flatten.jl")
 include("parameters_base.jl")

--- a/src/parameters_matrix.jl
+++ b/src/parameters_matrix.jl
@@ -98,7 +98,7 @@ struct PositiveDefinite{TL<:AbstractVector{<:Real},Tε<:Real} <: AbstractParamet
     ε::Tε
 end
 
-Base.:(==)(X::PositiveDefinite, Y::PositiveDefinite) = X.L == Y.L
+Base.:(==)(X::PositiveDefinite, Y::PositiveDefinite) = X.L == Y.L && X.ε == Y.ε
 
 value(X::PositiveDefinite) = A_At(vec_to_tril(X.L)) + X.ε * I
 

--- a/src/parameters_matrix.jl
+++ b/src/parameters_matrix.jl
@@ -39,14 +39,20 @@ function flatten(::Type{T}, X::Orthogonal) where {T<:Real}
 end
 
 """
-    positive_definite(X::AbstractMatrix{<:Real})
+    positive_semidefinite(X::AbstractMatrix{<:Real})
 
-Produce a parameter whose `value` is constrained to be a positive-definite matrix. The argument `X` needs to
+Produce a parameter whose `value` is constrained to be a positive-semidefinite matrix. The argument `X` needs to
 be a positive-definite matrix (see https://en.wikipedia.org/wiki/Definite_matrix).
 
 The unconstrained parameter is a `LowerTriangular` matrix, stored as a vector.
+
+!!! warning
+    Even though the matrix needs to be positive-definite upon construction, the
+    unconstrained parameter can become zero, which represents a matrix which is merely
+    positive-semidefinite. To get a matrix that is always strictly positive-definite, use
+    `positive_definite`.
 """
-function positive_definite(X::AbstractMatrix{<:Real})
+function positive_semidefinite(X::AbstractMatrix{<:Real})
     isposdef(X) || throw(ArgumentError("X is not positive-definite"))
     return PositiveSemiDefinite(tril_to_vec(cholesky(X).L))
 end

--- a/src/parameters_matrix.jl
+++ b/src/parameters_matrix.jl
@@ -48,23 +48,23 @@ The unconstrained parameter is a `LowerTriangular` matrix, stored as a vector.
 """
 function positive_definite(X::AbstractMatrix{<:Real})
     isposdef(X) || throw(ArgumentError("X is not positive-definite"))
-    return PositiveDefinite(tril_to_vec(cholesky(X).L))
+    return PositiveSemiDefinite(tril_to_vec(cholesky(X).L))
 end
 
-struct PositiveDefinite{TL<:AbstractVector{<:Real}} <: AbstractParameter
+struct PositiveSemiDefinite{TL<:AbstractVector{<:Real}} <: AbstractParameter
     L::TL
 end
 
-Base.:(==)(X::PositiveDefinite, Y::PositiveDefinite) = X.L == Y.L
+Base.:(==)(X::PositiveSemiDefinite, Y::PositiveSemiDefinite) = X.L == Y.L
 
 A_At(X) = X * X'
 
-value(X::PositiveDefinite) = A_At(vec_to_tril(X.L))
+value(X::PositiveSemiDefinite) = A_At(vec_to_tril(X.L))
 
-function flatten(::Type{T}, X::PositiveDefinite) where {T<:Real}
+function flatten(::Type{T}, X::PositiveSemiDefinite) where {T<:Real}
     v, unflatten_v = flatten(T, X.L)
-    unflatten_PositiveDefinite(v_new::Vector{T}) = PositiveDefinite(unflatten_v(v_new))
-    return v, unflatten_PositiveDefinite
+    unflatten_PositiveSemiDefinite(v_new::Vector{T}) = PositiveSemiDefinite(unflatten_v(v_new))
+    return v, unflatten_PositiveSemiDefinite
 end
 
 # Convert a vector to lower-triangular matrix

--- a/src/parameters_matrix.jl
+++ b/src/parameters_matrix.jl
@@ -68,7 +68,7 @@ be a positive real number.
 
 The unconstrained parameter is a `LowerTriangular` matrix, stored as a vector.
 """
-function positive_definite(X::AbstractMatrix{T}, ε = eps(T)) where T <: Real
+function positive_definite(X::AbstractMatrix{T}, ε=eps(T)) where {T<:Real}
     ε > 0 || throw(ArgumentError("ε is not positive. Use `positive_semidefinite` instead."))
     _X = X - ε * I
     isposdef(_X) || throw(ArgumentError("X-ε*I is not positive-definite for ε=$ε"))
@@ -87,11 +87,13 @@ value(X::PositiveSemiDefinite) = A_At(vec_to_tril(X.L))
 
 function flatten(::Type{T}, X::PositiveSemiDefinite) where {T<:Real}
     v, unflatten_v = flatten(T, X.L)
-    unflatten_PositiveSemiDefinite(v_new::Vector{T}) = PositiveSemiDefinite(unflatten_v(v_new))
+    function unflatten_PositiveSemiDefinite(v_new::Vector{T})
+        return PositiveSemiDefinite(unflatten_v(v_new))
+    end
     return v, unflatten_PositiveSemiDefinite
 end
 
-struct PositiveDefinite{TL<:AbstractVector{<:Real}, Tε<:Real} <: AbstractParameter
+struct PositiveDefinite{TL<:AbstractVector{<:Real},Tε<:Real} <: AbstractParameter
     L::TL
     ε::Tε
 end

--- a/test/parameters_matrix.jl
+++ b/test/parameters_matrix.jl
@@ -37,7 +37,7 @@ using ParameterHandling: vec_to_tril, tril_to_vec
         @test vec_to_tril(X.L) ≈ cholesky(X_mat).L
 
         # Zeroing the unconstrained value preserve positivity
-        X.L .= 0 
+        X.L .= 0
         @test isposdef(value(X))
 
         # Check that zeroing the unconstrained value does not affect the original array

--- a/test/parameters_matrix.jl
+++ b/test/parameters_matrix.jl
@@ -62,7 +62,7 @@ using ParameterHandling: vec_to_tril, tril_to_vec
         X.L .= 0 # zero the unconstrained value
         @test isposdef(value(X))
         @test_throws ArgumentError positive_definite(zeros(3, 3))
-        @test_throws ArgumentError positive_definite(X_mat, 0.)
+        @test_throws ArgumentError positive_definite(X_mat, 0.0)
         test_parameter_interface(X)
 
         x, re = flatten(X)

--- a/test/parameters_matrix.jl
+++ b/test/parameters_matrix.jl
@@ -62,7 +62,7 @@ using ParameterHandling: vec_to_tril, tril_to_vec
         X.L .= 0 # zero the unconstrained value
         @test isposdef(value(X))
         @test X != positive_definite(X_mat)
-        @test positive_definite(X_mat, 1e-3) != positive_definite(X_mat, 1e-2)
+        @test positive_definite(X_mat, 1e-5) != positive_definite(X_mat, 1e-6)
         @test_throws ArgumentError positive_definite(zeros(3, 3))
         @test_throws ArgumentError positive_definite(X_mat, 0.0)
         test_parameter_interface(X)

--- a/test/parameters_matrix.jl
+++ b/test/parameters_matrix.jl
@@ -61,6 +61,8 @@ using ParameterHandling: vec_to_tril, tril_to_vec
         @test isposdef(value(X))
         X.L .= 0 # zero the unconstrained value
         @test isposdef(value(X))
+        @test X != positive_definite(X_mat)
+        @test positive_definite(X_mat, 1e-3) != positive_definite(X_mat, 1e-2)
         @test_throws ArgumentError positive_definite(zeros(3, 3))
         @test_throws ArgumentError positive_definite(X_mat, 0.0)
         test_parameter_interface(X)

--- a/test/parameters_matrix.jl
+++ b/test/parameters_matrix.jl
@@ -24,47 +24,29 @@ using ParameterHandling: vec_to_tril, tril_to_vec
         end
     end
 
-    @testset "positive_semidefinite" begin
+    @testset "positive_definite" begin
         @testset "vec_tril_conversion" begin
             X = tril!(rand(3, 3))
             @test vec_to_tril(tril_to_vec(X)) == X
             @test_throws ErrorException tril_to_vec(rand(4, 5))
         end
         X_mat = ParameterHandling.A_At(rand(3, 3)) # Create a positive definite object
-        X = positive_semidefinite(X_mat)
-        @test X == X
+        X = positive_definite(X_mat)
         @test value(X) ≈ X_mat
         @test isposdef(value(X))
         @test vec_to_tril(X.L) ≈ cholesky(X_mat).L
-        @test_throws ArgumentError positive_semidefinite(rand(3, 3))
-        test_parameter_interface(X)
 
-        x, re = flatten(X)
-        Δl = first(
-            Zygote.gradient(x) do x
-                X = re(x)
-                return logdet(value(X))
-            end,
-        )
-        ΔL = first(
-            Zygote.gradient(vec_to_tril(X.L)) do L
-                return logdet(L * L')
-            end,
-        )
-        @test vec_to_tril(Δl) == tril(ΔL)
-        ChainRulesTestUtils.test_rrule(vec_to_tril, x)
-    end
+        # Zeroing the unconstrained value preserve positivity
+        X.L .= 0 
+        @test isposdef(value(X))
 
-    @testset "positive_definite" begin
-        X_mat = ParameterHandling.A_At(rand(3, 3)) # Create a positive definite object
-        X = positive_definite(X_mat)
-        @test isposdef(value(X))
-        X.L .= 0 # zero the unconstrained value
-        @test isposdef(value(X))
+        # Check that zeroing the unconstrained value does not affect the original array
         @test X != positive_definite(X_mat)
+
         @test positive_definite(X_mat, 1e-5) != positive_definite(X_mat, 1e-6)
         @test_throws ArgumentError positive_definite(zeros(3, 3))
         @test_throws ArgumentError positive_definite(X_mat, 0.0)
+
         test_parameter_interface(X)
 
         x, re = flatten(X)

--- a/test/parameters_matrix.jl
+++ b/test/parameters_matrix.jl
@@ -24,19 +24,19 @@ using ParameterHandling: vec_to_tril, tril_to_vec
         end
     end
 
-    @testset "positive_definite" begin
+    @testset "positive_semidefinite" begin
         @testset "vec_tril_conversion" begin
             X = tril!(rand(3, 3))
             @test vec_to_tril(tril_to_vec(X)) == X
             @test_throws ErrorException tril_to_vec(rand(4, 5))
         end
         X_mat = ParameterHandling.A_At(rand(3, 3)) # Create a positive definite object
-        X = positive_definite(X_mat)
+        X = positive_semidefinite(X_mat)
         @test X == X
         @test value(X) ≈ X_mat
         @test isposdef(value(X))
         @test vec_to_tril(X.L) ≈ cholesky(X_mat).L
-        @test_throws ArgumentError positive_definite(rand(3, 3))
+        @test_throws ArgumentError positive_semidefinite(rand(3, 3))
         test_parameter_interface(X)
 
         x, re = flatten(X)


### PR DESCRIPTION
In contrast to `Positive`, the current `PositiveDefinite` type is not guaranteed to stay strictly positive as the unconstrained parameter goes to zero. This PR changes that to make the behavior of `PositiveDefinite` analogous to `Positive`, and introduces a new type for the existing behavior. Open questions:
- What is a good default value for epsilon? `Positive` uses `sqrt(eps(T))`, not sure where this is coming from. I picked `eps(T)` for now as the other one seemed too big.
- Is this considered breaking and if yes, is this a problem? Personally, I think that although this is technically breaking, this would not be too disruptive. If it is considered too breaking or a breaking release is not desirable, I would be perfectly happy to change naming such that the strict one becomes the one with a new name (e.g. `StrictlyPositiveDefinite`) and the existing name keeps behavior.
